### PR TITLE
Use `python-gnupg` module instead of `gpg` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,31 @@ This is an Ansible collection to sign / verify playbooks and roles in a SCM repo
 You can sign your own playbooks and roles, and also verify them by calling this module in a playbook.
 This is useful for checking playbook file integrity before actual PlaybookRun.
 
+## Installation
+```
+# make a collection package file
+$ ansible-galaxy collection build .
+
+# install it as a collection
+$ ansible-galaxy collection install ./playbook-integrity-1.0.0.tar.gz
+```
+
 ## Usage
 
 ```
-# sign
+# sign with GPG default private key
 $ ansible-playbook playbooks/sign-playbook.yml -e repo=<PATH/TO/REPO>
 
-$ verify
+$ verify with GPG default public key
 $ ansible-playbook playbooks/verify-playbook.yml -e repo=<PATH/TO/REPO>
+```
+
+Also you can specify the keyring file such as `pubring.gpg` as below
+
+```
+# sign with the specific private key
+$ ansible-playbook playbooks/sign-playbook.yml -e repo=<PATH/TO/REPO> -e key=<PATH/TO/PRIVATE_KEY>
+
+$ verify with the specific public key
+$ ansible-playbook playbooks/verify-playbook.yml -e repo=<PATH/TO/REPO> -e key=<PATH/TO/PUBLIC_KEY>
 ```

--- a/playbooks/sign-playbook.yml
+++ b/playbooks/sign-playbook.yml
@@ -5,6 +5,7 @@
   tasks:
   - name: Sign a playbook SCM repository
     playbook.integrity.sign:
+      pwd: "{{ lookup('env', 'PWD') }}"
       target: "{{ repo | default('<PATH/TO/REPO>') }}"
       signature_type: "{{ sigtype | default('gpg') }}"
       private_key: "{{ key | default('') }}"   # if empty, use gpg's default keyring

--- a/playbooks/verify-playbook.yml
+++ b/playbooks/verify-playbook.yml
@@ -5,6 +5,7 @@
   tasks:
   - name: Verify a playbook SCM repository
     playbook.integrity.verify:
+      pwd: "{{ lookup('env', 'PWD') }}"
       target: "{{ repo | default('<PATH/TO/REPO>') }}"
       signature_type: "{{ sigtype | default('gpg') }}"
       public_key: "{{ key | default('') }}"   # if empty, use gpg's default keyring

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -122,14 +122,15 @@ class Digester:
         return result
 
 def result_object_to_dict(obj):
-    if not isinstance(obj, subprocess.CompletedProcess):
-        return {}
-    
-    return dict(
-        returncode=obj.returncode,
-        stdout=obj.stdout,
-        stderr=obj.stderr,
-    )
+    if isinstance(obj, subprocess.CompletedProcess):
+        failed = (obj.returncode != 0)
+        return dict(
+            failed=failed,
+            returncode=obj.returncode,
+            stdout=obj.stdout,
+            stderr=obj.stderr,
+        )
+    return {}
 
 def execute_command(cmd="", env_params=None, timeout=None):
     env = None

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -20,7 +20,6 @@ SIGNATURE_FILENAME_GPG = "sha256sum.txt.sig"
 SIGNATURE_FILENAME_SIGSTORE = "sha256sum.txt.sig"
 
 CHECKSUM_OK_IDENTIFIER = ": OK"
-TMP_GNUPG_HOME_DIR = "/tmp/gpghome"
 TMP_COSIGN_PATH = "/tmp/cosign"
 
 class Digester:
@@ -176,3 +175,23 @@ def get_cosign_path():
         return TMP_COSIGN_PATH
     else:
         raise ValueError("failed to install cosign command; {}".format(result["stderr"]))
+
+def validate_path(pwd, fpath):
+    vaild_path = ""
+    if os.path.exists(fpath):
+        vaild_path = os.path.abspath(fpath)
+
+    if vaild_path == "" and fpath.startswith("~/"):
+        expanded_fpath = os.path.expanduser(fpath)
+        if os.path.exists(expanded_fpath):
+            vaild_path = expanded_fpath
+
+    if vaild_path == "":
+        joined_path = os.path.join(pwd, fpath)
+        if os.path.exists(joined_path):
+            vaild_path = joined_path
+
+    if vaild_path == "":
+        raise ValueError("file not found for the path \"{}\"".format(fpath))
+    
+    return vaild_path

--- a/plugins/module_utils/sign.py
+++ b/plugins/module_utils/sign.py
@@ -7,13 +7,13 @@ import ansible_collections.playbook.integrity.plugins.module_utils.common as com
 
 class Signer:
     def __init__(self, params):
+        self.pwd = params.get("pwd", "")
         self.type = params.get("type", "")
-        self.target = params.get("target", "")
-        if self.target.startswith("~/"):
-            self.target = os.path.expanduser(self.target)
+        self.target = common.validate_path(self.pwd, params.get("target", ""))
         self.signature_type = params.get("signature_type", "gpg")
         self.private_key = params.get("private_key", "")
-        self.public_key = params.get("public_key", "")
+        if self.private_key != "":
+            self.private_key = common.validate_path(self.pwd, self.private_key)
         self.keyless_signer_id = params.get("keyless_signer_id", "")
 
     def sign(self):
@@ -36,11 +36,11 @@ class Signer:
             sig_file = os.path.join(self.target, common.SIGNATURE_FILENAME_GPG)
             if os.path.exists(sig_file):
                 os.remove(sig_file) # remove privious signature before signing
-            result["sign_result"] = self.sign_gpg(self.target, common.DIGEST_FILENAME)
+            result["sign_result"] = self.sign_gpg(self.target, common.DIGEST_FILENAME, common.SIGNATURE_FILENAME_GPG, self.private_key)
         elif self.signature_type in [common.SIGNATURE_TYPE_SIGSTORE, common.SIGNATURE_TYPE_SIGSTORE_KEYLESS]:
             keyless = True if self.signature_type == common.SIGNATURE_TYPE_SIGSTORE_KEYLESS else False
             type = common.SIGSTORE_TARGET_TYPE_FILE
-            result["sign_result"] = self.sign_sigstore(self.target, target_type=type, keyless=keyless, filename=common.DIGEST_FILENAME)
+            result["sign_result"] = self.sign_sigstore(self.target, common.DIGEST_FILENAME, common.SIGNATURE_FILENAME_SIGSTORE, private_key=self.private_key, keyless=keyless, target_type=type)
         else:
             raise ValueError("this signature type is not supported: {}".format(self.signature_type))
         # set overall result
@@ -48,52 +48,44 @@ class Signer:
             result["failed"] = True
         return result
 
-    def sign_gpg(self, path, filename):
-        if self.private_key == "":
-            raise ValueError("a private key must be specified fot GPG signing")
+    def sign_gpg(self, path, msgfile, sigfile, private_key):
+        use_gpg_default_key = False
+        if private_key == "":
+            use_gpg_default_key = True
 
         if not os.path.exists(path):
             raise ValueError("the directory \"{}\" does not exists".format(path))
 
-        filepath = os.path.join(path, filename)
-        sigpath = os.path.join(path, common.SIGNATURE_FILENAME_GPG)
-        result = {}
-        with tempfile.TemporaryDirectory() as dname:
-            gpg = gnupg.GPG(gnupghome=dname)
+        sigpath = os.path.join(path, sigfile)
+        msgpath = os.path.join(path, msgfile)
+        result = None
+        if use_gpg_default_key:
+            gpg = gnupg.GPG()
+            result = gpg.sign_file(file=open(msgpath, "rb"), detach=True, output=sigpath)
+        else:
+            # use a temp dir as gnupg home to disable default GPG keyrings
+            with tempfile.TemporaryDirectory() as temp_dir:
+                gpg = gnupg.GPG(gnupghome=temp_dir)
+                try:
+                    gpg.import_keys(open(private_key, "r").read())
+                except:
+                    try:
+                        gpg.import_keys(open(private_key, "rb").read())
+                    except:
+                        raise
+                result = gpg.sign_file(file=open(msgpath, "rb"), detach=True, output=sigpath)
+        failed = result.returncode != 0
+        return {"failed": failed, "returncode": result.returncode, "stderr": result.stderr}
 
-            # import the secret key to the temporary keyring
-            with open(self.private_key, "r") as private_key_file:
-                key_data = private_key_file.read()
-                import_result = gpg.import_keys(key_data)
-                if import_result.returncode != 0:
-                    result["failed"] = True
-                    result["returncode"] = import_result.returncode
-                    result["error"] = import_result.stderr
-                    return result 
-
-            # sign the message file
-            with open(filepath, "r") as file:
-                signed_data = gpg.sign_file(file=file, detach=True, output=sigpath)
-                if signed_data.returncode != 0:
-                    result["failed"] = True
-                    result["returncode"] = signed_data.returncode
-                    result["error"] = signed_data.stderr
-                    return result
-
-        result["failed"] = False
-        result["returncode"] = 0
-        result["error"] = ""
-        return result
-
-    def sign_sigstore(self, target, target_type=common.SIGSTORE_TARGET_TYPE_FILE, keyless=False, filename=common.DIGEST_FILENAME):
+    def sign_sigstore(self, path, msgfile, sigfile, private_key="", keyless=False, target_type=common.SIGSTORE_TARGET_TYPE_FILE):
         result = None
         if target_type == common.SIGSTORE_TARGET_TYPE_FILE:
-            result = self.sign_sigstore_file(self.target, filename=filename, keyless=keyless)
+            result = self.sign_sigstore_file(path, msgfile, sigfile, private_key, keyless)
         else:
             raise ValueError("this target type \"{}\" is not supported for sigstore signing".format(target_type))
         return result
     
-    def sign_sigstore_file(self, path, filename, keyless=False, sigfile=common.SIGNATURE_FILENAME_SIGSTORE):
+    def sign_sigstore_file(self, path, msgfile, sigfile, private_key="", keyless=False):
         if not os.path.exists(path):
             raise ValueError("the directory \"{}\" does not exists".format(path))
         
@@ -106,9 +98,9 @@ class Signer:
             experimental_option = "COSIGN_EXPERIMENTAL=1"
             idtoken_option = "--identity-token {}".format(self.keyless_signer_id)
         else:
-            key_option = "--key {}".format(self.private_key)
+            key_option = "--key {}".format(private_key)
 
-        cmd = "cd {}; {} {} sign-blob {} {} {} {}".format(path, experimental_option, cosign_cmd, key_option, idtoken_option, output_option, filename)
+        cmd = "cd {}; {} {} sign-blob {} {} {} {}".format(path, experimental_option, cosign_cmd, key_option, idtoken_option, output_option, msgfile)
         result = common.execute_command(cmd)
         return result        
 

--- a/plugins/modules/sign.py
+++ b/plugins/modules/sign.py
@@ -89,6 +89,7 @@ from ansible_collections.playbook.integrity.plugins.module_utils.sign import Sig
 def run_module():
     # define available arguments/parameters a user can pass to the module
     module_args = dict(
+        pwd=dict(type='str', required=False, default=""),
         type=dict(type='str', required=False, default="playbook"),
         target=dict(type='str', required=True),
         signature_type=dict(type='str', required=False, default="gpg"),

--- a/plugins/modules/verify.py
+++ b/plugins/modules/verify.py
@@ -84,6 +84,7 @@ from ansible_collections.playbook.integrity.plugins.module_utils.verify import V
 def run_module():
     # define available arguments/parameters a user can pass to the module
     module_args = dict(
+        pwd=dict(type='str', required=False, default=""),
         type=dict(type='str', required=False, default="playbook"),
         target=dict(type='str', required=True),
         signature_type=dict(type='str', required=False, default="gpg"),


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- change to use `python-gnupg` module as backend for GPG signing & verification. `gpg` command is never used.