### PR TITLE
support passphrase and remove command execution except cosign

### DIFF
--- a/playbooks/sign-playbook.yml
+++ b/playbooks/sign-playbook.yml
@@ -9,6 +9,8 @@
       target: "{{ repo | default('<PATH/TO/REPO>') }}"
       signature_type: "{{ sigtype | default('gpg') }}"
       private_key: "{{ key | default('') }}"   # if empty, use gpg's default keyring
+      keyid: "{{ keyid | default(omit) }}"  # gpg key id such as "Email" and "Real Name" in the key attributes
+      passphrase: "{{ passphrase | default(omit) }}"  # key passphrase
     register: result
     # ignore_errors: yes
 

--- a/plugins/modules/sign.py
+++ b/plugins/modules/sign.py
@@ -94,7 +94,8 @@ def run_module():
         target=dict(type='str', required=True),
         signature_type=dict(type='str', required=False, default="gpg"),
         private_key=dict(type='str', required=False, default=""),
-        public_key=dict(type='str', required=False, default=""),
+        keyid=dict(type='str', required=False, default=""),
+        passphrase=dict(type='str', required=False, default=""),
         keyless_signer_id=dict(type='str', required=False, default=""),
     )
 


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- support `keyid` and `passphrase` for signing so that users can specify the key id to be used and can use key with passphrase
- remove all command execution except cosign in order to avoid incompatibility issue (like BSD vs GNU)